### PR TITLE
#157918917 Fix pages access based on authentication status

### DIFF
--- a/ui/auth/signin.html
+++ b/ui/auth/signin.html
@@ -32,7 +32,7 @@
             <input class="input-field" type="password" placeholder="Enter password">
           </div>
 
-          <button class="btn btn--block btn--primary" type="submit">Sign up</button>
+          <button class="btn btn--block btn--primary" type="submit">Sign in</button>
         </form>
       </div>
       <div class="card__footer">

--- a/ui/index.html
+++ b/ui/index.html
@@ -23,18 +23,6 @@
         </svg>
       </li>
       <li class="sidebar__link-item mobile-item">
-        <a href="pages/requests.html" class="link link--sidebar mobile-link">Requests</a>
-        <svg class="icon icon--sidebar mobile-icon">
-          <use xlink:href="assets/icons/sprite.svg#icon-layers"></use>
-        </svg>
-      </li>
-      <li class="sidebar__link-item mobile-item">
-        <a href="pages/new-request.html" class="link link--sidebar mobile-link">Make request</a>
-        <svg class="icon icon--sidebar mobile-icon">
-          <use xlink:href="assets/icons/sprite.svg#icon-activity"></use>
-        </svg>
-      </li>
-      <li class="sidebar__link-item mobile-item">
         <a href="auth/signup.html" class="link link--sidebar mobile-link">Create account</a>
         <svg class="icon icon--sidebar mobile-icon">
           <use xlink:href="assets/icons/sprite.svg#icon-user"></use>
@@ -59,12 +47,6 @@
       </svg>
 
       <ul class="nav--right">
-        <li class="nav__item">
-          <a href="pages/requests.html" class="nav__link">Requests</a>
-        </li>
-        <li class="nav__item">
-          <a href="pages/new-request.html" class="nav__link">Make Request</a>
-        </li>
         <li class="nav__item">
           <a href="auth/signin.html" class="nav__link">Sign in</a>
         </li>

--- a/ui/pages/new-request.html
+++ b/ui/pages/new-request.html
@@ -35,15 +35,9 @@
         </svg>
       </li>
       <li class="sidebar__link-item mobile-item">
-        <a href="../auth/signup.html" class="link link--sidebar mobile-link">Create account</a>
+        <a href="#" class="link link--sidebar mobile-link">Sign outt</a>
         <svg class="icon icon--sidebar mobile-icon">
-          <use xlink:href="../assets/icons/sprite.svg#icon-user"></use>
-        </svg>
-      </li>
-      <li class="sidebar__link-item mobile-item">
-        <a href="../auth/signin.html" class="link link--sidebar mobile-link">Sign in</a>
-        <svg class="icon icon--sidebar mobile-icon">
-          <use xlink:href="../assets/icons/sprite.svg#icon-log-in"></use>
+          <use xlink:href="../assets/icons/sprite.svg#icon-log-out"></use>
         </svg>
       </li>
     </ul>
@@ -64,12 +58,16 @@
         <li class="nav__item">
           <a href="new-request.html" class="nav__link">Make Request</a>
         </li>
-        <li class="nav__item">
-          <a href="../auth/signin.html" class="nav__link">Sign in</a>
-        </li>
-        <li class="nav__item nav__item--signup">
-          <a href="../auth/signup.html" class="nav__link text-blue">Create Account</a>
-        </li>
+        <button class="btn--dropdown" id="signout-btn">
+          Dennis Wanjiru
+          <svg class="icon">
+            <use xlink:href="../assets/icons/sprite.svg#icon-chevron-down"></use>
+          </svg>
+        </button>
+
+        <div id="signout" class="hidden">
+          <a href="#">Sign out</a>
+        </div>
       </ul>
     </nav>
   </header>
@@ -126,6 +124,21 @@
       </div>
     </section>
   </main>
+  <div class="actions--right hidden">
+    <button class="btn--dropdown" id="filter-btn">
+    </button>
+
+    <div id="filters" class="hidden">
+    </div>
+
+    <div class="dropdown">
+      <button class="btn--dropdown" id="sort-btn">
+      </button>
+
+      <div id="sort" class="hidden">
+      </div>
+    </div>
+  </div>
 
   <footer class="footer">
     <div class="footer__content">
@@ -164,6 +177,7 @@
     <div class="copyright">
       <span>&copy; 2018 M-tracker. All Rights Reserved</span>
     </div>
+    <script src="../static/js/dropdown.js"></script>
     <script src="../static/js/mobile-nav.js"></script>
   </footer>
 </body>

--- a/ui/pages/requests.html
+++ b/ui/pages/requests.html
@@ -35,15 +35,9 @@
         </svg>
       </li>
       <li class="sidebar__link-item mobile-item">
-        <a href="../auth/signup.html" class="link link--sidebar mobile-link">Create account</a>
+        <a href="#" class="link link--sidebar mobile-link">Sign outt</a>
         <svg class="icon icon--sidebar mobile-icon">
-          <use xlink:href="../assets/icons/sprite.svg#icon-user"></use>
-        </svg>
-      </li>
-      <li class="sidebar__link-item mobile-item">
-        <a href="../auth/signin.html" class="link link--sidebar mobile-link">Sign in</a>
-        <svg class="icon icon--sidebar mobile-icon">
-          <use xlink:href="../assets/icons/sprite.svg#icon-log-in"></use>
+          <use xlink:href="../assets/icons/sprite.svg#icon-log-out"></use>
         </svg>
       </li>
     </ul>
@@ -64,12 +58,17 @@
         <li class="nav__item">
           <a href="new-request.html" class="nav__link">Make Request</a>
         </li>
-        <li class="nav__item">
-          <a href="../auth/signin.html" class="nav__link">Sign in</a>
-        </li>
-        <li class="nav__item nav__item--signup">
-          <a href="../auth/signup.html" class="nav__link text-blue">Create Account</a>
-        </li>
+
+        <!-- <button class="btn--dropdown" id="signout-btn">
+          Dennis Wanjiru
+          <svg class="icon">
+            <use xlink:href="../assets/icons/sprite.svg#icon-chevron-down"></use>
+          </svg>
+        </button>
+
+        <div id="signout" class="hidden">
+          <a href="#">Sign out</a>
+        </div> -->
       </ul>
     </nav>
   </header>

--- a/ui/static/js/dropdown.js
+++ b/ui/static/js/dropdown.js
@@ -1,18 +1,29 @@
+const signoutClasses = document.querySelector("#signout").classList;
 const filterClasses = document.querySelector("#filters").classList;
 const sortClasses = document.querySelector("#sort").classList;
 const sortBtn = document.querySelector("#sort-btn");
+const signoutBtn = document.querySelector("#signout-btn");
 const filterBtn = document.querySelector("#filter-btn");
 
 const toggleDropdown = searchType => {
   if (searchType.contains("hidden")) {
     searchType.replace("hidden", "dropdown__content");
+
+    if (searchType === signoutClasses) {
+      searchType.add("dropdown--signout");
+    }
   } else {
     searchType.replace("dropdown__content", "hidden");
+
+    if (searchType === signoutClasses) {
+      searchType.remove("dropdown--signout");
+    }
   }
 };
 
 filterBtn.addEventListener("click", () => toggleDropdown(filterClasses));
 sortBtn.addEventListener("click", () => toggleDropdown(sortClasses));
+signoutBtn.addEventListener("click", () => toggleDropdown(signoutClasses));
 
 window.addEventListener("click", e => {
   if (!e.target.matches(".btn--dropdown")) {

--- a/ui/static/styles.css
+++ b/ui/static/styles.css
@@ -359,6 +359,18 @@ span {
   margin-top: 1rem;
 }
 
+#signout-btn,
+#signout-btn .icon {
+  color: #fff;
+  fill: #fff;
+}
+
+.dropdown--signout {
+  top: 6rem;
+  right: 0;
+  z-index: 99999;
+}
+
 .dropdown__content a {
   padding: 1rem 2rem;
   font-size: 1.4rem;


### PR DESCRIPTION
#### What does this PR do?
This PR will fix the rendered pages simulation based off authentication status

#### Description of Task to be completed?
- Remove authentication links on pages meant for authenticated users
- Remove links to pages meant for authenticated user on guests' pages
- Fix sign in typo

#### How should this be manually tested?
1. Clone the branch into your local machine as follows
```
git clone -b bg-render-links-authentically-157918917 git@github.com:DennisWanjiru/maintenance-tracker.git 

cd maintenance-tracker/ui/pages/

```
2. Open `requests.html` with a browser
3. Open `new-requests.html` with a browser

#### Any background context you want to provide?
It's just simulation not actual implementation of the authentication middleware

#### What are the relevant pivotal tracker stories?
[#157918917](https://www.pivotaltracker.com/story/show/157918917)